### PR TITLE
support newer key names for ICE states in trace events

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,9 +173,12 @@ function processTraceEvent(table, event) {
         switch(event.value) {
         case 'ICEConnectionStateConnected':
         case 'ICEConnectionStateCompleted':
+        case 'kICEConnectionStateConnected':
+        case 'kICEConnectionStateCompleted':
             row.style.backgroundColor = 'green';
             break;
         case 'ICEConnectionStateFailed':
+        case 'kICEConnectionStateFailed':
             row.style.backgroundColor = 'red';
             break;
         }


### PR DESCRIPTION
Chrome seems to now be prepending their ICE connection states with a 'k'