### PR TITLE
adds support for per-report timestamps

### DIFF
--- a/rtcstats.html
+++ b/rtcstats.html
@@ -334,7 +334,7 @@ function processConnections(connectionIds, data) {
                             series[id].type = stats[id].type;
                         }
                         if (!series[id][name]) series[id][name] = [];
-                        series[id][name].push([new Date(connection[i].time).getTime(), stats[id][name]]);
+                        series[id][name].push([stats[id].timestamp || new Date(connection[i].time).getTime(), stats[id][name]]);
                     }
                 });
             });

--- a/rtcstats.html
+++ b/rtcstats.html
@@ -333,7 +333,14 @@ function processConnections(connectionIds, data) {
                             series[id] = {};
                             series[id].type = stats[id].type;
                         }
-                        if (!series[id][name]) series[id][name] = [];
+                        if (!series[id][name]) {
+                            series[id][name] = [];
+                        } else {
+                            var lastTime = series[id][name][series[id][name].length - 1][0];
+                            if (lastTime && stats[id].timestamp && stats[id].timestamp - lastTime > 5000) {
+                                series[id][name].push([stats[id].timestamp || new Date(connection[i].time).getTime(), null]);
+                            }
+                        }
                         series[id][name].push([stats[id].timestamp || new Date(connection[i].time).getTime(), stats[id][name]]);
                     }
                 });


### PR DESCRIPTION
in https://github.com/opentok/rtcstats-server/issues/56 we have some issues with streams/stats that are temporarily removed from the peerconnection which means we need change the timestamp behaviour.
See also https://github.com/opentok/rtcstats/pull/83

This change is still able to read both old and new format