### PR TITLE
Replaces Highcharts with Plotly/d3.js.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,3 @@ Just use that hash in the URL to specify a connection id, start time, stop time 
 ## License
 MIT
 
-Note that the (awesome) Highcharts library used for plots may need a license. See http://shop.highsoft.com/faq/non-commercial

--- a/index.html
+++ b/index.html
@@ -2,10 +2,7 @@
     <head>
         <meta charset="utf-8">
         <title>Import webrtc-internals dumps</title>
-        <!-- highcharts is used under the terms of
-            http://shop.highsoft.com/faq/non-commercial
-        -->
-        <script src="https://code.highcharts.com/highcharts.js"></script>
+        <script src="https://cdn.plot.ly/plotly-2.18.2.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.4/pako.js"></script>
         <script src="sdp.js"></script>
         <script src="import.js"></script>


### PR DESCRIPTION
Hi @fippo 👋 we have replaced Highcharts with Plotly/d3.js because of its more permissive license. If you are interested in adopting this change, I can try to migrate all the other charts you have in the project.

EDIT: You can review how the new graphs look like here https://gpolitis.github.io/webrtc-dump-importer/